### PR TITLE
Add supplier logo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,4 @@ source 'https://rubygems.org'
 
 gem 'spree', github: 'spree/spree', branch: 'master'
 
-# Provides higher-level image processing helpers that are commonly needed when handling image uploads.
-gem 'image_processing', '~> 1.2'
-
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,7 @@ source 'https://rubygems.org'
 
 gem 'spree', github: 'spree/spree', branch: 'master'
 
+# Provides higher-level image processing helpers that are commonly needed when handling image uploads.
+gem 'image_processing', '~> 1.2'
+
 gemspec

--- a/app/controllers/spree/admin/suppliers_controller.rb
+++ b/app/controllers/spree/admin/suppliers_controller.rb
@@ -1,6 +1,6 @@
 module Spree
   module Admin
-    class SuppliersController < ResourceController
+    class SuppliersController < ResourceController    
     end
   end
 end

--- a/app/models/spree/supplier.rb
+++ b/app/models/spree/supplier.rb
@@ -1,6 +1,7 @@
 class Spree::Supplier < ActiveRecord::Base
   has_many :volume_prices, -> { order(position: :asc) }, dependent: :destroy
   belongs_to :stock_location, dependent: :destroy
+  has_one_attached :logo
   validates :name, presence: true, uniqueness: true
 
   before_validation :create_stock_location

--- a/app/models/spree/supplier.rb
+++ b/app/models/spree/supplier.rb
@@ -1,7 +1,7 @@
 class Spree::Supplier < ActiveRecord::Base
   has_many :volume_prices, -> { order(position: :asc) }, dependent: :destroy
   belongs_to :stock_location, dependent: :destroy
-  has_one_attached :logo
+  has_many_attached :logos
   validates :name, presence: true, uniqueness: true
 
   before_validation :create_stock_location

--- a/app/views/spree/admin/suppliers/_form.html.erb
+++ b/app/views/spree/admin/suppliers/_form.html.erb
@@ -5,10 +5,10 @@
       <%= error_message_on :supplier, :name, :class => 'error-message' %>
       <%= text_field :supplier, :name, :class => 'form-control' %>
     <% end %>
-    <%= form.field_container :logo, class: ['form-group'] do %>
-      <%= form.label :logo, Spree.t(:logo) %> <span class="required">*</span>
-      <%= error_message_on :supplier, :logo, :class => 'error-message' %>
-      <%= file_field :supplier, :logo, :class => 'form-control' %>
+    <%= form.field_container :logos, class: ['form-group'] do %>
+      <%= form.label :logos, Spree.t(:logos) %> <span class="required">*</span>
+      <%= error_message_on :supplier, :logos, :class => 'error-message' %>
+      <%= file_field :supplier, :logos,  multiple: true, :class => 'form-control' %>
     <% end %>    
   </div>
 

--- a/app/views/spree/admin/suppliers/_form.html.erb
+++ b/app/views/spree/admin/suppliers/_form.html.erb
@@ -5,6 +5,11 @@
       <%= error_message_on :supplier, :name, :class => 'error-message' %>
       <%= text_field :supplier, :name, :class => 'form-control' %>
     <% end %>
+    <%= form.field_container :logo, class: ['form-group'] do %>
+      <%= form.label :logo, Spree.t(:logo) %> <span class="required">*</span>
+      <%= error_message_on :supplier, :logo, :class => 'error-message' %>
+      <%= file_field :supplier, :logo, :class => 'form-control' %>
+    <% end %>    
   </div>
 
   <%= render 'spree/admin/shared/edit_resource_links' %>

--- a/app/views/spree/admin/suppliers/_form.html.erb
+++ b/app/views/spree/admin/suppliers/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [:admin, spree_supplier] do |form| %>
+<%= form_for [:admin, spree_supplier], html: { multipart: true } do |form| %>
   <div data-hook="admin_inside_supplier_form" class="form-group">
     <%= form.field_container :name, class: ['form-group'] do %>
       <%= form.label :name, Spree.t(:name) %> <span class="required">*</span>

--- a/app/views/spree/admin/suppliers/index.html.erb
+++ b/app/views/spree/admin/suppliers/index.html.erb
@@ -10,9 +10,9 @@
 
 <table class="table sortable" id='listing_supplier_models' data-hook data-sortable-link="<%#= update_positions_admin_volume_price_models_url %>">
   <thead>
-    <tr data-hook="suppliers_header">
-      <th><%= Spree.t(:logo) %></th>
+    <tr data-hook="suppliers_header">      
       <th><%= Spree.t(:name) %></th>
+      <th><%= Spree.t(:logo) %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/app/views/spree/admin/suppliers/index.html.erb
+++ b/app/views/spree/admin/suppliers/index.html.erb
@@ -19,8 +19,14 @@
   <tbody>
     <% @suppliers.each do |supplier| %>
       <tr id="<%= spree_dom_id supplier %>" data-hook="suppliers_row">
-        <td><%= image_tag supplier.logo.variant(resize_to_fit: [100, 100]) %></td>
         <td><%= supplier.name %></td>
+        <td>
+          <% if supplier.logo.attached? %>
+            <%= image_tag supplier.logo.variant(resize_to_fit: [100, 100]) %>
+          <% else %>
+            No logo yet
+          <% end %>
+        </td>        
         <td class="actions actions-2 text-right">
           <%= link_to_edit supplier.id, no_text: true %>
           <%= link_to_delete supplier, no_text: true %>

--- a/app/views/spree/admin/suppliers/index.html.erb
+++ b/app/views/spree/admin/suppliers/index.html.erb
@@ -11,6 +11,7 @@
 <table class="table sortable" id='listing_supplier_models' data-hook data-sortable-link="<%#= update_positions_admin_volume_price_models_url %>">
   <thead>
     <tr data-hook="suppliers_header">
+      <th><%= Spree.t(:logo) %></th>
       <th><%= Spree.t(:name) %></th>
       <th class="actions"></th>
     </tr>
@@ -18,6 +19,7 @@
   <tbody>
     <% @suppliers.each do |supplier| %>
       <tr id="<%= spree_dom_id supplier %>" data-hook="suppliers_row">
+        <td><%= image_tag supplier.logo.variant(resize_to_fit: [100, 100]) %></td>
         <td><%= supplier.name %></td>
         <td class="actions actions-2 text-right">
           <%= link_to_edit supplier.id, no_text: true %>

--- a/app/views/spree/admin/suppliers/index.html.erb
+++ b/app/views/spree/admin/suppliers/index.html.erb
@@ -22,7 +22,7 @@
         <td><%= supplier.name %></td>
         <td>
           <% if supplier.logo.attached? %>
-            <%= image_tag(Rails.application.routes.url_helpers.rails_blob_path(supplier.logo, only_path: true)) %>
+            <%= image_tag Rails.application.routes.url_helpers.rails_blob_path(supplier.logo, only_path: true), style: 'max-width: 300px; max-height: 40px;' %>
           <% else %>
             No logo yet
           <% end %>

--- a/app/views/spree/admin/suppliers/index.html.erb
+++ b/app/views/spree/admin/suppliers/index.html.erb
@@ -21,8 +21,10 @@
       <tr id="<%= spree_dom_id supplier %>" data-hook="suppliers_row">
         <td><%= supplier.name %></td>
         <td>
-          <% if supplier.logo.attached? %>
-            <%= image_tag Rails.application.routes.url_helpers.rails_blob_path(supplier.logo, only_path: true), style: 'max-width: 300px; max-height: 40px;' %>
+          <% if supplier.logos.attached? %>
+            <% supplier.logos.each do |logo| %>
+              <%= image_tag Rails.application.routes.url_helpers.rails_blob_path(logo, only_path: true), style: 'max-width: 300px; max-height: 40px;' %>
+            <% end %>
           <% else %>
             No logo yet
           <% end %>

--- a/app/views/spree/admin/suppliers/index.html.erb
+++ b/app/views/spree/admin/suppliers/index.html.erb
@@ -22,9 +22,7 @@
         <td><%= supplier.name %></td>
         <td>
           <% if supplier.logos.attached? %>
-            <% supplier.logos.each do |logo| %>
-              <%= image_tag Rails.application.routes.url_helpers.rails_blob_path(logo, only_path: true), style: 'max-width: 300px; max-height: 40px;' %>
-            <% end %>
+            <%= image_tag Rails.application.routes.url_helpers.rails_blob_path(supplier.logos.first, only_path: true), style: 'max-width: 300px; max-height: 40px;' %>
           <% else %>
             No logo yet
           <% end %>

--- a/app/views/spree/admin/suppliers/index.html.erb
+++ b/app/views/spree/admin/suppliers/index.html.erb
@@ -22,7 +22,7 @@
         <td><%= supplier.name %></td>
         <td>
           <% if supplier.logo.attached? %>
-            <%= image_tag supplier.logo.variant(resize_to_fit: [100, 100]) %>
+            <%= image_tag(Rails.application.routes.url_helpers.rails_blob_path(supplier.logo, only_path: true)) %>
           <% else %>
             No logo yet
           <% end %>


### PR DESCRIPTION
Add Logo to Supplier #44

In the Backend Admin portal we have a Supplier model. We need to add an attached logo using Active Storage. We need to support two logos, a color logo and a black and white logo.

The Model needs to be updated and the UI needs to be updated to support this functionality.

NOTE: This functionality needs to be added in the volume_pricing_gem not in this repo. Specifically in this branch

https://github.com/brettallred/spree_volume_pricing/tree/brett/suppliers

Logos can be found in the project public/theme/assets/img/vendor-logos/

![image](https://user-images.githubusercontent.com/14852261/45932283-684da800-bfac-11e8-840c-b8b9a6df4408.png)

![image](https://user-images.githubusercontent.com/14852261/45932373-a7c8c400-bfad-11e8-9a5e-6fd118fbe663.png)

